### PR TITLE
Adding support for files larger than 2GB

### DIFF
--- a/libdonard/filemap.c
+++ b/libdonard/filemap.c
@@ -80,7 +80,7 @@ static void copy_filename(struct filemap *fm, const char *fname)
 
 struct filemap *filemap_alloc_local(int fd, const char *fname)
 {
-    struct stat stats;
+    struct stat64 stats;
     if (fstat(fd, &stats))
         return NULL;
 
@@ -134,7 +134,7 @@ static void free_local_nvme(struct filemap *fm)
 struct filemap *filemap_alloc_local_nvme(int fd, const char *fname)
 {
     int map_error;
-    struct stat st;
+    struct stat64 st;
     if (fstat(fd, &st))
         return NULL;
 
@@ -225,7 +225,7 @@ static void free_cuda(struct filemap *fm)
 
 struct filemap *filemap_alloc_cuda(int fd, const char *fname)
 {
-    struct stat stats;
+    struct stat64 stats;
     if (fstat(fd, &stats))
         return NULL;
 
@@ -354,7 +354,7 @@ static void free_cuda_nvme(struct filemap *fm)
 struct filemap *filemap_alloc_cuda_nvme(int fd, const char *fname)
 {
     int map_error=0;
-    struct stat st;
+    struct stat64 st;
     if (fstat(fd, &st))
         return NULL;
 
@@ -439,7 +439,7 @@ struct filemap *filemap_open_cuda_nvme(const char *fname)
 int filemap_write_cuda_nvme(struct filemap *fmap, int fd)
 {
     int ret;
-    struct stat st;
+    struct stat64 st;
 
     if (fmap->type != FILEMAP_TYPE_CUDA) {
         errno = EINVAL;

--- a/libdonard/nvme_dev.c
+++ b/libdonard/nvme_dev.c
@@ -61,7 +61,7 @@ static int find_dev(dev_t dev)
         if (entry->d_type != DT_UNKNOWN  && entry->d_type != DT_BLK)
             continue;
 
-        struct stat st;
+        struct stat64 st;
         if (fstatat(dirfd(dp), entry->d_name, &st, 0))
             continue;
 
@@ -102,7 +102,7 @@ int nvme_dev_find(dev_t dev)
     return devfd;
 }
 
-int nvme_dev_get_sector_list(int fd, struct stat *st,
+int nvme_dev_get_sector_list(int fd, struct stat64 *st,
                              struct nvme_dev_sector **slist_p,
                              size_t max_size)
 {
@@ -211,7 +211,7 @@ int nvme_dev_gpu_write(int devfd, int slba, int nblocks,
 
 int nvme_dev_read_fd(int fd, void *buf, size_t bufsize)
 {
-    struct stat st;
+    struct stat64 st;
     if (fstat(fd, &st))
         return -1;
 
@@ -270,7 +270,7 @@ int nvme_dev_read_file(const char *fname, void *buf, size_t bufsize)
 
 int nvme_dev_write_fd(int fd, const void *buf, size_t bufsize)
 {
-    struct stat st;
+    struct stat64 st;
     if (fstat(fd, &st))
         return -1;
 

--- a/libdonard/nvme_dev.h
+++ b/libdonard/nvme_dev.h
@@ -40,7 +40,7 @@ struct nvme_dev_sector {
     unsigned long count;
 };
 
-int nvme_dev_get_sector_list(int fd, struct stat *st,
+int nvme_dev_get_sector_list(int fd, struct stat64 *st,
                              struct nvme_dev_sector **slist,
                              size_t max_size);
 


### PR DESCRIPTION
Changes struct stat to struct stat64 in filemap.c, nvme_dev.c nvme_dev.h to allow access for files larger than 2GB
